### PR TITLE
Fix broken sidebar links by making them root-relative

### DIFF
--- a/index.html
+++ b/index.html
@@ -768,10 +768,10 @@ generators into code that can be run in any ES5-compatible web browser.</p>
   <h1>Talks</h1>
   <ul id="talks">
     <li><a href="http://opensourcebridge.org/sessions/1067">Mod your Android</a></li>
-    <li><a href="talks/intro-to-javascript/">Introduction to JavaScript</a></li>
+    <li><a href="/talks/intro-to-javascript/">Introduction to JavaScript</a></li>
     <li><a href="http://lanyrd.com/2012/nodepdx/smyqm/">Object-oriented patterns in JavaScript</a></li>
-    <li><a href="talks/cookies/">Cookies are bad for you</a></li>
-    <li><a href="talks/professional-javascript/">Professional JavaScript</a></li>
+    <li><a href="/talks/cookies/">Cookies are bad for you</a></li>
+    <li><a href="/talks/professional-javascript/">Professional JavaScript</a></li>
     <li><a href="http://opensourcebridge.org/2009/wiki/Clustering_Data_--_How_to_Have_Fun_in_n-Dimensions">Cluster Analysis: How to Have Fun in n Dimensions</a></li>
     <li><a href="https://docs.google.com/presentation/d/1hx9Pzo07aAnZ2skMH4JPjH7a6IXx64uC0zRliS3qpkk/edit?usp=sharing">How to build blazing fast web apps with Ruby on Rails</a></li>
   </ul>


### PR DESCRIPTION
On blog post pages such as http://sitr.us/2018/05/13/build-xmonad-with-stack.html, the sidebar links were to http://sitr.us/2018/05/13/talks/intro-to-javascript/ instead of to the actual http://sitr.us/talks/intro-to-javascript/.